### PR TITLE
Add option to disable swipe bumping(?) (makes it go too far)

### DIFF
--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -120,6 +120,10 @@ export default {
       type: Number,
       default: 8
     },
+    swipeBump: {
+      type: Boolean,
+      default: false
+    },
     /**
      * Amount of padding to apply around the label in pixels
      */
@@ -549,7 +553,10 @@ export default {
         const width = this.scrollPerPage
           ? this.slideWidth * this.currentPerPage
           : this.slideWidth;
-        this.dragOffset = this.dragOffset + Math.sign(deltaX) * (width / 2);
+
+        if (this.swipeBump) {
+          this.dragOffset = this.dragOffset + Math.sign(deltaX) * (width / 2);
+        }
       }
 
       this.offset += this.dragOffset;


### PR DESCRIPTION
The dragging swiping is well over sensitive and tends to go an extra item too far (expected behaviour is that it'll lock onto the item most in view, but it seems to go an extra bit of distance based on the swipe direction)